### PR TITLE
Allow insecure connection on source uri

### DIFF
--- a/plugins/module_utils/prism/images.py
+++ b/plugins/module_utils/prism/images.py
@@ -83,6 +83,13 @@ class Image(Prism):
 
     def _build_spec_source_uri(self, payload, source_uri):
         payload["spec"]["resources"]["source_uri"] = source_uri
+
+        # We need to ensure source_options exists so we can set allow_insecure_connection
+        if "source_options" not in payload["spec"]["resources"]:
+            payload["spec"]["resources"]["source_options"] = {}
+
+        allow_insecure = self.module.params.get("source_uri_allow_insecure_connection", False)
+        payload["spec"]["resources"]["source_options"]["allow_insecure_connection"] = allow_insecure
         return payload, None
 
     def _build_spec_checksum(self, payload, checksum):

--- a/plugins/modules/ntnx_images.py
+++ b/plugins/modules/ntnx_images.py
@@ -329,6 +329,7 @@ def get_module_spec():
         name=dict(type="str", required=False),
         desc=dict(type="str", required=False),
         source_uri=dict(type="str", required=False),
+        source_uri_allow_insecure_connection=dict(type="bool", required=False, default=False),
         source_path=dict(type="str", required=False),
         remove_categories=dict(type="bool", required=False, default=False),
         categories=dict(type="dict", required=False),


### PR DESCRIPTION
We're running into issues where we can't validate the certs in our S3 bucket. Adding an option to ignore that cert